### PR TITLE
ZBUG-1707: Fix for the deprecated message in zimbra.log for clamav option ArchiveBlockEncrypted

### DIFF
--- a/clamd.conf.in
+++ b/clamd.conf.in
@@ -430,7 +430,7 @@ User zimbra
 
 # Mark encrypted archives as viruses (Encrypted.Zip, Encrypted.RAR).
 # Default: no
-%%uncomment VAR:zimbraVirusBlockEncryptedArchive%%ArchiveBlockEncrypted yes
+%%uncomment VAR:zimbraVirusBlockEncryptedArchive%%AlertEncryptedArchive yes
 
 
 ##


### PR DESCRIPTION
**Problem:**
A deprecated message is seen in `zimbra.log` for `ClamAV` option `ArchiveBlockEncrypted` while starting the services.
```
Jul 28 08:52:41 zimbra-demo clamd[3988]: Using deprecated option "ArchiveBlockEncrypted" to alert on encrypted archives _and_ documents. Please update your configuration to use replacement options "AlertEncrypted", or "AlertEncryptedArchive" and/or "AlertEncryptedDoc".
```
**Approach and Fix:**
Since `ArchiveBlockEncrypted` is mapped to the LDAP attribute `zimbraVirusBlockEncryptedArchive`, which is causing this deprecated waring to show, to fix this now the `AlertEncryptedArchive` is mapped to the `zimbraVirusBlockEncryptedArchive`.

**Testing Done:**
- Verified after updating the `ClamAV` option to `AlertEncryptedArchive` the above-deprecated message is not observed.