### PR TITLE
ZBUG-2948 : add support to mark encrypted archives and documents as viruses

### DIFF
--- a/clamd.conf.in
+++ b/clamd.conf.in
@@ -430,7 +430,7 @@ User zimbra
 
 # Mark encrypted archives as viruses (Encrypted.Zip, Encrypted.RAR).
 # Default: no
-%%uncomment VAR:zimbraVirusBlockEncryptedArchive%%AlertEncryptedArchive yes
+%%uncomment VAR:zimbraVirusBlockEncryptedArchive%%AlertEncrypted yes
 
 
 ##


### PR DESCRIPTION
**Problem:**

[ZBUG-2948](https://jira.corp.synacor.com/browse/ZBUG-2948) : Getting below deprecated warning in clamd.log
`WARNING: Using deprecated option "ArchiveBlockEncrypted" to alert on encrypted archives _and_ documents. Please update your configuration to use replacement options "AlertEncrypted", or "AlertEncryptedArchive" and/or "AlertEncryptedDoc".`

**Fix :**
This issue was fixed in [ZBUG-1707 ](https://jira.corp.synacor.com/browse/ZBUG-1707)-> https://github.com/Zimbra/zm-mta/pull/1
But there is one issue with [ZBUG-1707 ](https://jira.corp.synacor.com/browse/ZBUG-1707) fix. 
Fix of  [ZBUG-1707 ](https://jira.corp.synacor.com/browse/ZBUG-1707) not marking encrypted .pdf as virus. We are fixing this issue as part of [ZBUG-2948 ](https://jira.corp.synacor.com/browse/ZBUG-2948).

**Old Config:**
ArchiveBlockEncrypted BOOL
Mark encrypted archives as viruses (Encrypted.Zip, Encrypted.RAR, Encrypted..pdf).
Default: no

**New Config:**
AlertEncrypted BOOL
Alert on encrypted archives and documents (encrypted .zip, .7zip, .rar, .pdf).
Default: no

AlertEncryptedArchive BOOL
Alert on encrypted archives (encrypted .zip, .7zip, .rar).
Default: no

AlertEncryptedDoc BOOL
Alert on encrypted documents (encrypted .pdf).
Default: no

`ArchiveBlockEncrypted` is deprecated, replacing `ArchiveBlockEncrypted` with `AlertEncrypted`